### PR TITLE
NBA LeaderBoard/30_Days_of_Python#306

### DIFF
--- a/30_days_of_python/NBA.py
+++ b/30_days_of_python/NBA.py
@@ -1,0 +1,92 @@
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+from pprint import PrettyPrinter
+
+# Suppress only the single InsecureRequestWarning from urllib3
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+BASE_URL = "https://cdn.nba.com"
+ALL_JSON = "/static/json/liveData/odds/odds_todaysGames.json"
+
+printer = PrettyPrinter()
+
+def get_links():
+    url = BASE_URL + ALL_JSON
+    print(f"Fetching URL: {url}")
+    try:
+        response = requests.get(url, verify=False)
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Content: {response.text}")
+        response.raise_for_status()
+        data = response.json()
+        return data.get('links', {})
+    except requests.exceptions.HTTPError as e:
+        print(f"HTTP Error occurred: {e.response.status_code} - {e.response.text}")
+        return None
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred: {e}")
+        return None
+
+def get_scoreboard():
+    links = get_links()
+    if not links:
+        return
+
+    scoreboard = links.get('currentScoreboard')
+    if not scoreboard:
+        print("Scoreboard data not found")
+        return
+
+    url = BASE_URL + scoreboard
+    print(f"Fetching URL: {url}")
+    try:
+        response = requests.get(url, verify=False)
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Content: {response.text}")
+        games = response.json().get('games', [])
+
+        for game in games:
+            home_team = game['hTeam']
+            away_team = game['vTeam']
+            clock = game['clock']
+            period = game['period']
+
+            print("------------------------------------------")
+            print(f"{home_team['triCode']} vs {away_team['triCode']}")
+            print(f"{home_team['score']} - {away_team['score']}")
+            print(f"{clock} - {period['current']}")
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred while fetching scoreboard data: {e}")
+
+def get_stats():
+    links = get_links()
+    if not links:
+        return
+
+    stats = links.get('leagueTeamStatsLeaders')
+    if not stats:
+        print("Stats data not found")
+        return
+
+    url = BASE_URL + stats
+    print(f"Fetching URL: {url}")
+    try:
+        response = requests.get(url, verify=False)
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Content: {response.text}")
+        teams = response.json().get('league', {}).get('standard', {}).get('regularSeason', {}).get('teams', [])
+
+        teams = list(filter(lambda x: x['name'] != "Team", teams))
+        teams.sort(key=lambda x: int(x['ppg']['rank']))
+
+        for i, team in enumerate(teams):
+            name = team['name']
+            nickname = team['nickname']
+            ppg = team['ppg']['avg']
+            print(f"{i + 1}. {name} - {nickname} - {ppg}")
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred while fetching stats data: {e}")
+
+# Example usage
+get_scoreboard()
+get_stats()


### PR DESCRIPTION
## Overview
This Pull Request introduces a feature that fetches and displays the NBA (National Basketball Association) leaderboard. The application retrieves live data from the NBA API and displays the current scoreboard and team statistics.

## Features Added
1. *Fetching Links:*
   - Retrieves the necessary endpoints from the NBA's live data API.
   - URL: https://cdn.nba.com/static/json/liveData/odds/odds_todaysGames.json

2. *Displaying Scoreboard:*
   - Fetches and displays the current scoreboard, including team scores, clock, and period information.
   - Sample endpoint: /currentScoreboard

3. *Displaying Team Stats:*
   - Fetches and displays team statistics, such as points per game (PPG).
   - Teams are sorted based on their ranking in PPG.
   - Sample endpoint: /leagueTeamStatsLeaders

## Requirements
- *Endpoints:* Ensure you have the correct base URL and endpoints. You may need to adjust parameters like year, language, and season to fit specific needs.
- *Suppressed SSL Warnings:* SSL warnings are suppressed for this script, allowing you to run the requests without SSL verification.
- *Libraries Used:*
  - requests
  - urllib3 for disabling SSL warnings
  - pprint for pretty-printing the output

## Notes
- Add your URL with the appropriate query parameters to customize the data retrieval based on your requirements (e.g., year, language, season).

## Testing
- The script has been tested locally, and it fetches and displays the leaderboard as expected.