### PR TITLE
NBA LeaderBoard/30_Days_of_Python #306

### DIFF
--- a/30_days_of_python/NBA_30_Days_of_python/NBA.py
+++ b/30_days_of_python/NBA_30_Days_of_python/NBA.py
@@ -1,0 +1,92 @@
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+from pprint import PrettyPrinter
+
+# Suppress only the single InsecureRequestWarning from urllib3
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+BASE_URL = "https://cdn.nba.com"
+ALL_JSON = "/static/json/liveData/odds/odds_todaysGames.json"
+
+printer = PrettyPrinter()
+
+def get_links():
+    url = BASE_URL + ALL_JSON
+    print(f"Fetching URL: {url}")
+    try:
+        response = requests.get(url, verify=False)
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Content: {response.text}")
+        response.raise_for_status()
+        data = response.json()
+        return data.get('links', {})
+    except requests.exceptions.HTTPError as e:
+        print(f"HTTP Error occurred: {e.response.status_code} - {e.response.text}")
+        return None
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred: {e}")
+        return None
+
+def get_scoreboard():
+    links = get_links()
+    if not links:
+        return
+
+    scoreboard = links.get('currentScoreboard')
+    if not scoreboard:
+        print("Scoreboard data not found")
+        return
+
+    url = BASE_URL + scoreboard
+    print(f"Fetching URL: {url}")
+    try:
+        response = requests.get(url, verify=False)
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Content: {response.text}")
+        games = response.json().get('games', [])
+
+        for game in games:
+            home_team = game['hTeam']
+            away_team = game['vTeam']
+            clock = game['clock']
+            period = game['period']
+
+            print("------------------------------------------")
+            print(f"{home_team['triCode']} vs {away_team['triCode']}")
+            print(f"{home_team['score']} - {away_team['score']}")
+            print(f"{clock} - {period['current']}")
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred while fetching scoreboard data: {e}")
+
+def get_stats():
+    links = get_links()
+    if not links:
+        return
+
+    stats = links.get('leagueTeamStatsLeaders')
+    if not stats:
+        print("Stats data not found")
+        return
+
+    url = BASE_URL + stats
+    print(f"Fetching URL: {url}")
+    try:
+        response = requests.get(url, verify=False)
+        print(f"Response Status Code: {response.status_code}")
+        print(f"Response Content: {response.text}")
+        teams = response.json().get('league', {}).get('standard', {}).get('regularSeason', {}).get('teams', [])
+
+        teams = list(filter(lambda x: x['name'] != "Team", teams))
+        teams.sort(key=lambda x: int(x['ppg']['rank']))
+
+        for i, team in enumerate(teams):
+            name = team['name']
+            nickname = team['nickname']
+            ppg = team['ppg']['avg']
+            print(f"{i + 1}. {name} - {nickname} - {ppg}")
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred while fetching stats data: {e}")
+
+# Example usage
+get_scoreboard()
+get_stats()

--- a/30_days_of_python/NBA_30_Days_of_python/readme.md
+++ b/30_days_of_python/NBA_30_Days_of_python/readme.md
@@ -1,0 +1,18 @@
+"National Basketball Association" Leaderboard Application
+This Python application interacts with the "National Basketball Association" (NBA) API to fetch and display real-time game scores and team statistics. It uses the requests library to make HTTP requests and processes JSON data from the NBA's online resources.
+
+**Features**
+Scoreboard Fetching: Retrieves the current scoreboard, showing live NBA game scores, periods, and clock status.
+Team Stats Leaderboard: Displays the league's top teams based on points per game (PPG), along with rankings and additional stats.
+
+**Requirements**
+Python 3.x
+Requests library: You can install it using pip install requests
+PrettyPrinter (for clean output formatting)
+
+**Customizing API Requests**
+To fetch specific data, you can modify the API request URL to include parameters such as year, language, and season. This allows you to retrieve information based on different seasons, languages, and specific years. Adjust these parameters in the URL according to your needs:
+
+Base URL: https://cdn.nba.com
+Scoreboard Endpoint: /static/json/liveData/odds/odds_todaysGames.json
+Team Stats Endpoint: /static/json/liveData/odds/odds_todaysGames.json


### PR DESCRIPTION
"National Basketball Association" Leaderboard Application
This Python application interacts with the "National Basketball Association" (NBA) API to fetch and display real-time game scores and team statistics. It uses the requests library to make HTTP requests and processes JSON data from the NBA's online resources.

Features
Scoreboard Fetching: Retrieves the current scoreboard, showing live NBA game scores, periods, and clock status.
Team Stats Leaderboard: Displays the league's top teams based on points per game (PPG), along with rankings and additional stats.

Requirements
Python 3.x
Requests library: You can install it using pip install requests
PrettyPrinter (for clean output formatting)